### PR TITLE
Removed duplicate titles from page bodies

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,7 +5,6 @@ permalink: about/
 
 ---
 
-# About Us
 Make, Hack, Void Inc is a community association based in Canberra, Australia.
 
 ## Mission Statement

--- a/contacts.md
+++ b/contacts.md
@@ -4,9 +4,6 @@ title: Contacts
 permalink: contact/
 
 ---
-#Contact Us
-
-
 
 ## In Person
 

--- a/mailinglist-guidelines.md
+++ b/mailinglist-guidelines.md
@@ -5,8 +5,6 @@ permalink: mailing-list-guidelines/
 
 ---
 
-# Mailing List Guidelines
-
 Our [Code of Conduct](code-of-conduct/) applies to mailing list discussions.
 
 ## How Mailing Lists Work

--- a/projects/ammo-counter-nerf.md
+++ b/projects/ammo-counter-nerf.md
@@ -7,9 +7,6 @@ excerpt: The ammo counter, the most ubiquitous and humble of FPS game elements, 
 
 ---
 
-Ammo Counter for Nerf Gun
-====================
-
 *wil5on — Tue, 21/06/2011 - 12:58pm*
 
 The ammo counter, the most ubiquitous and humble of FPS game elements, but completely absent from Nerf combat (apart from some transparent magazines). I decided to remedy this!

--- a/projects/arduino-controlled-robotic-hand.md
+++ b/projects/arduino-controlled-robotic-hand.md
@@ -7,9 +7,6 @@ excerpt: One of my ongoing projects (I started it when I was about 15 years old 
 
 ---
 
-Arduino controlled robotic hand
-====================
-
 *Combust — Thu, 20/05/2010 - 4:32pm*
 
 

--- a/projects/ddr-board-dreamcast.md
+++ b/projects/ddr-board-dreamcast.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: DDR board for the Dreamcast.
+title: DDR board for the Dreamcast
 permalink: projects/ddr-board-dreamcast/
 category: projects
 excerpt:

--- a/projects/rfid-locker.md
+++ b/projects/rfid-locker.md
@@ -7,9 +7,6 @@ excerpt: It took me a little a few hours and couple brews to install the lock. T
 
 ---
 
-RFID Access For Locker - Journal
-====================
-
 *Australian Robotics — Sat, 12/02/2011 - 6:21pm*
 
 ![Locker Done](/assets/projects/rfid-locker/rfidLockerDone.jpg)


### PR DESCRIPTION
Some content pages had a title in the body text as well as the front matter - as front matter title was already being used in a `<h1>` tag by the template, this caused duplicate titles on these pages.

Also removed a full stop for funsies.
