### PR TITLE
Load custom page JS when YAML flag is set

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,5 +5,6 @@
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="/js/jquery.js"></script>
     <script src="/bootstrap/js/bootstrap.min.js"></script>
+    {% if page.js == true %}<script src="/js/pages/{{page.path | replace: '.html', '.js' | replace: '.md', '.js'}}"></script>{% endif %}
   </body>
 </html>


### PR DESCRIPTION
Loads a Javascript file for a page when a flag is set in the YAML front matter.

The `.js` file must be located at `/js/*location of page without extension*.js`. For example, the `.js` file for `/foo/bar.html` would be at `/js/foo/bar.js`.

To activate this behaviour, add `js: true` to the front matter.
