### PR TITLE
mv project pages to _posts sub dir

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -5,8 +5,7 @@ permalink: projects/
 
 ---
 
-{% for page in site.pages %}
-{% if page.category == 'projects' %}
+{% for page in site.categories.projects %}
 	<article>
 		<h3><a href="{{page.url}}">{{page.title}}</a></h3>
 		<section class="post-preview">
@@ -20,5 +19,4 @@ permalink: projects/
 	{% unless forloop.last %}
 	<hr>
 	{% endunless %}
-{% endif %}
 {% endfor %}

--- a/projects/_posts/2010-05-18-emiglio-refit.md
+++ b/projects/_posts/2010-05-18-emiglio-refit.md
@@ -2,7 +2,6 @@
 layout: default
 title: Emiglio Refit
 permalink: projects/emiglio-refit/
-category: projects
 excerpt: Refitting an Emiglio/Scooter robot with new control systems.
 
 ---

--- a/projects/_posts/2010-05-20-arduino-controlled-robotic-hand.md
+++ b/projects/_posts/2010-05-20-arduino-controlled-robotic-hand.md
@@ -2,7 +2,6 @@
 layout: default
 title: Arduino controlled robotic hand
 permalink: projects/arduino-controlled-robotic-hand/
-category: projects
 excerpt: One of my ongoing projects (I started it when I was about 15 years old with an aluminium one) has been a robot hand but only recently have I been able to easily make something that will control multiple hobby servos. Hooray Arduinos!
 
 ---

--- a/projects/_posts/2010-06-10-ddr-board-dreamcast.md
+++ b/projects/_posts/2010-06-10-ddr-board-dreamcast.md
@@ -2,7 +2,6 @@
 layout: default
 title: DDR board for the Dreamcast
 permalink: projects/ddr-board-dreamcast/
-category: projects
 excerpt: A DDR (Dance Dance Revolution) board for the Dreamcast.
 
 ---

--- a/projects/_posts/2010-11-01-robosapien-w-bluetooth-remote.md
+++ b/projects/_posts/2010-11-01-robosapien-w-bluetooth-remote.md
@@ -2,7 +2,6 @@
 layout: default
 title: Robosapien w/ Bluetooth remote control
 permalink: projects/robosapien-w-bluetooth-remote/
-category: projects
 excerpt: This is about a Sunday afternoon spent attaching a Seeeduino (Arduino clone) and a Bluetooth serial module to the Robosapien, then remote controlling him from a Python shell.
 
 ---

--- a/projects/_posts/2011-02-12-rfid-locker.md
+++ b/projects/_posts/2011-02-12-rfid-locker.md
@@ -2,7 +2,6 @@
 layout: default
 title: RFID Access For Locker - Journal
 permalink: projects/rfid-locker/
-category: projects
 excerpt: It took me a little a few hours and couple brews to install the lock. The whole assembly fit's quite nicely on the inside of the door, and the RFID action is quite reliable. Next step, RFID the rolling shed doors!
 
 ---

--- a/projects/_posts/2011-02-18-async-firefly.md
+++ b/projects/_posts/2011-02-18-async-firefly.md
@@ -2,7 +2,6 @@
 layout: default
 title: ASync-Firefly
 permalink: projects/async-firefly/
-category: projects
 excerpt: An Analog Synchronising Firefly very heavily inspired by the Synchronising Firefly kit from Alex at Tinkerlog.
 
 ---

--- a/projects/_posts/2011-05-21-space-probe.md
+++ b/projects/_posts/2011-05-21-space-probe.md
@@ -2,7 +2,6 @@
 layout: default
 title: Space Probe
 permalink: projects/space-probe/
-category: projects
 excerpt: Need to tell people when the Hackerspace is open for hacking? Use the Space Probe! It tweets & emails to let people know when the space opens and closes.
 
 ---

--- a/projects/_posts/2011-06-21-ammo-counter-nerf.md
+++ b/projects/_posts/2011-06-21-ammo-counter-nerf.md
@@ -2,7 +2,6 @@
 layout: default
 title: Ammo Counter for Nerf Gun
 permalink: projects/ammo-counter-nerf/
-category: projects
 excerpt: The ammo counter, the most ubiquitous and humble of FPS game elements, but completely absent from Nerf combat (apart from some transparent magazines). I decided to remedy this!
 
 ---

--- a/projects/_posts/2012-03-16-pc-to-pcb.md
+++ b/projects/_posts/2012-03-16-pc-to-pcb.md
@@ -2,7 +2,6 @@
 layout: default
 title: PC to PCB
 permalink: projects/pc-to-pcb/
-category: projects
 excerpt: How do you get an Eagle File etched onto a PCB in 30 minutes? This technique is some amalgamations of various how-tos and guides I've read on the internet over the years - so many aspects are probably famliar to some of you.
 thumbnail: /assets/projects/pc-to-pcb/thumbnail.png
 

--- a/projects/_posts/2012-08-05-huxbox.md
+++ b/projects/_posts/2012-08-05-huxbox.md
@@ -2,7 +2,6 @@
 layout: default
 title: HuxBox - a box for the space's Rep Rap Huxley 3D printer
 permalink: projects/huxbox/
-category: projects
 excerpt: I designed and made an acrylic box to hold our Rep Rap Pro Huxley 3d printer.
 
 ---


### PR DESCRIPTION
This turns each of the projects into a 'post' in the category 'projects'
automatically. This is helpful for listing them as site.categories.projects

This patch also updates the projects.html file to use said listing
